### PR TITLE
Release 11/21/2020

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "axios": "^0.18.1",
     "clone": "^2.1.2",
     "date-fns": "^1.30.1",
-    "lodash": "^4.17.13",
+    "lodash": "^4.17.19",
     "loglevel": "^1.6.1",
     "number-to-words": "1.2.4",
     "url-join": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "eslint": "^5.8.0",
     "eslint-plugin-vue": "^5.0.0",
     "git-revision-webpack-plugin": "3.0.3",
-    "node-sass": "^4.9.0",
+    "node-sass": "^4.13.1",
     "sass-loader": "^7.0.1",
     "vue-template-compiler": "^2.5.21"
   }

--- a/src/game/Canvas.js
+++ b/src/game/Canvas.js
@@ -99,7 +99,7 @@ export class Canvas {
     this._drawBorder()
   }
 
-  clear (type, dots) {
+  clear (dots) {
     this._clear(this._contextGame, dots)
   }
 

--- a/src/game/Playground.js
+++ b/src/game/Playground.js
@@ -281,14 +281,14 @@ export class Playground {
           if (this._highlightPlayerSnakeIsActive()) {
             const objectType = this._highlightPlayerSnakeObjectType()
             this._canvas.draw(objectType, draw)
-            this._canvas.clear(objectType, clear)
+            this._canvas.clear(clear)
           } else {
             this._canvas.draw(OBJECT_PLAYER, draw)
-            this._canvas.clear(OBJECT_PLAYER, clear)
+            this._canvas.clear(clear)
           }
         } else {
           this._canvas.draw(OBJECT_SNAKE, draw)
-          this._canvas.clear(OBJECT_SNAKE, clear)
+          this._canvas.clear(clear)
         }
         this._cacheSnakes.set(object.id, object)
         break
@@ -304,7 +304,7 @@ export class Playground {
         }
         const { clear, draw } = dotListsDifference(object.dots, corpse.dots)
         this._canvas.draw(OBJECT_CORPSE, draw)
-        this._canvas.clear(OBJECT_CORPSE, clear)
+        this._canvas.clear(clear)
         this._cacheFood.set(object.id, object)
         break
       }
@@ -315,7 +315,7 @@ export class Playground {
         }
         const { clear, draw } = dotListsDifference(object.dots, watermelon.dots)
         this._canvas.draw(OBJECT_WATERMELON, draw)
-        this._canvas.clear(OBJECT_WATERMELON, clear)
+        this._canvas.clear(clear)
         this._cacheFood.set(object.id, object)
         break
       }
@@ -325,7 +325,7 @@ export class Playground {
           throw new Error(`Playground: mouse to update was not found: ${object.id}`)
         }
         this._canvas.draw(OBJECT_MOUSE, [object.dot])
-        this._canvas.clear(OBJECT_MOUSE, [mouse.dot])
+        this._canvas.clear([mouse.dot])
         this._cacheFood.set(object.id, object)
         break
       }
@@ -336,7 +336,7 @@ export class Playground {
         }
         const { clear, draw } = dotListsDifference(object.dots, wall.dots)
         this._canvas.draw(OBJECT_WALL, draw)
-        this._canvas.clear(OBJECT_WALL, clear)
+        this._canvas.clear(clear)
         this._cacheWalls.set(object.id, object)
         break
       }
@@ -350,11 +350,11 @@ export class Playground {
         if (_.has(object, 'dots')) {
           const { clear, draw } = dotListsDifference(object.dots, unknown.dots)
           this._canvas.draw(OBJECT_UNKNOWN, draw)
-          this._canvas.clear(OBJECT_UNKNOWN, clear)
+          this._canvas.clear(clear)
         } else if (_.has(object, 'dot')) {
           if (!dotsEqual(object.dot, unknown.dot)) {
             this._canvas.draw(OBJECT_UNKNOWN, [object.dot])
-            this._canvas.clear(OBJECT_UNKNOWN, [unknown.dot])
+            this._canvas.clear([unknown.dot])
           }
         } else {
           throw new Error(`Playground: object of unknown type does not have dot/dots field: ${object.type}`)
@@ -372,20 +372,20 @@ export class Playground {
         if (!this._cacheSnakes.delete(object.id)) {
           throw new Error(`Playground: snake object to delete was not found: ${object.id}`)
         }
-        this._canvas.clear(OBJECT_SNAKE, object.dots)
+        this._canvas.clear(object.dots)
         break
       case OBJECT_TYPE_APPLE:
         if (!this._cacheFood.delete(object.id)) {
           throw new Error(`Playground: apple object to delete was not found: ${object.id}`)
         }
-        this._canvas.clear(OBJECT_APPLE, [object.dot])
+        this._canvas.clear([object.dot])
         break
       case OBJECT_TYPE_CORPSE: {
         const corpse = this._cacheFood.get(object.id)
         if (corpse === undefined) {
           throw new Error(`Playground: corpse object to delete was not found: ${object.id}`)
         }
-        this._canvas.clear(OBJECT_CORPSE, corpse.dots)
+        this._canvas.clear(corpse.dots)
         this._cacheFood.delete(object.id)
         break
       }
@@ -394,7 +394,7 @@ export class Playground {
         if (watermelon === undefined) {
           throw new Error(`Playground: watermelon object to delete was not found: ${object.id}`)
         }
-        this._canvas.clear(OBJECT_WATERMELON, watermelon.dots)
+        this._canvas.clear(watermelon.dots)
         this._cacheFood.delete(object.id)
         break
       }
@@ -403,7 +403,7 @@ export class Playground {
         if (wall === undefined) {
           throw new Error(`Playground: wall object to delete was not found: ${object.id}`)
         }
-        this._canvas.clear(OBJECT_WALL, wall.dots)
+        this._canvas.clear(wall.dots)
         this._cacheWalls.delete(object.id)
         break
       }
@@ -412,7 +412,7 @@ export class Playground {
         if (mouse === undefined) {
           throw new Error(`Playground: mouse object to delete was not found: ${object.id}`)
         }
-        this._canvas.clear(OBJECT_MOUSE, [mouse.dot])
+        this._canvas.clear([mouse.dot])
         this._cacheFood.delete(object.id)
         break
       }
@@ -424,9 +424,9 @@ export class Playground {
         }
 
         if (_.has(object, 'dots')) {
-          this._canvas.clear(OBJECT_UNKNOWN, unknown.dots)
+          this._canvas.clear(unknown.dots)
         } else if (_.has(object, 'dot')) {
-          this._canvas.clear(OBJECT_UNKNOWN, [unknown.dot])
+          this._canvas.clear([unknown.dot])
         } else {
           throw new Error(`Playground: object of unknown type does not have dot/dots field: ${object.type}`)
         }

--- a/src/views/NotFound.vue
+++ b/src/views/NotFound.vue
@@ -1,6 +1,11 @@
 <template>
   <div class="notfound">
     <h1>404 Not Found</h1>
+    <div class="notfound-content">
+      <div>
+        <router-link to="/games">Back to games</router-link>
+      </div>
+    </div>
   </div>
 </template>
 <style lang="scss">
@@ -11,6 +16,16 @@
     h1 {
       text-align: center;
       font-size: 3rem;
+    }
+
+    .notfound-content {
+      max-width: 790px;
+      margin: 0 auto;
+
+      div {
+        margin: 50px 0px;
+        text-align: center;
+      }
     }
   }
 </style>

--- a/tests/unit/MouseController.spec.js
+++ b/tests/unit/MouseController.spec.js
@@ -2,7 +2,7 @@ import {
   DIRECTION_EAST,
   DIRECTION_NORTH,
   DIRECTION_SOUTH,
-  DIRECTION_WEST,
+  DIRECTION_WEST
 } from '@/game/BaseDeviceController'
 import MouseController from '@/game/MouseController'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9846,9 +9846,9 @@ websocket-driver@>=0.5.1:
     websocket-extensions ">=0.1.1"
 
 websocket-extensions@>=0.1.1:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.3.tgz#5d2ff22977003ec687a4b87073dfbbac146ccf29"
-  integrity sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.4.tgz#7f8473bc839dfd87608adb95d7eb075211578a42"
+  integrity sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==
 
 whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
   version "1.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3634,10 +3634,10 @@ event-pubsub@4.3.0:
   resolved "https://registry.yarnpkg.com/event-pubsub/-/event-pubsub-4.3.0.tgz#f68d816bc29f1ec02c539dc58c8dd40ce72cb36e"
   integrity sha512-z7IyloorXvKbFx9Bpie2+vMJKKx1fH1EN5yiTfp8CiLOTptSYy1g8H4yDpGlEdshL1PBiFtBHepF2cNsqeEeFQ==
 
-eventemitter3@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.0.tgz#090b4d6cdbd645ed10bf750d4b5407942d7ba163"
-  integrity sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==
+eventemitter3@^4.0.0:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
+  integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
 
 events@^1.0.0:
   version "1.1.1"
@@ -4095,11 +4095,9 @@ follow-redirects@1.5.10:
     debug "=3.1.0"
 
 follow-redirects@^1.0.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.6.0.tgz#d12452c031e8c67eb6637d861bfc7a8090167933"
-  integrity sha512-4Oh4eI3S9OueVV41AgJ1oLjpaJUhbJ7JDGOMhe0AFqoSejl5Q2nn3eGglAzRUKVKZE8jG5MNn66TjCJMAnpsWA==
-  dependencies:
-    debug "=3.1.0"
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.0.tgz#b42e8d93a2a7eea5ed88633676d6597bc8e384db"
+  integrity sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==
 
 for-in@^0.1.3:
   version "0.1.8"
@@ -4688,11 +4686,11 @@ http-proxy-middleware@~0.18.0:
     micromatch "^3.1.9"
 
 http-proxy@^1.16.2:
-  version "1.17.0"
-  resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.17.0.tgz#7ad38494658f84605e2f6db4436df410f4e5be9a"
-  integrity sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==
+  version "1.18.1"
+  resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.18.1.tgz#401541f0534884bbf95260334e72f88ee3976549"
+  integrity sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
   dependencies:
-    eventemitter3 "^3.0.0"
+    eventemitter3 "^4.0.0"
     follow-redirects "^1.0.0"
     requires-port "^1.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1736,9 +1736,9 @@ bluebird@^3.5.5:
   integrity sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==
 
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
-  version "4.11.8"
-  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
-  integrity sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==
+  version "4.11.9"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.9.tgz#26d556829458f9d1e81fc48952493d0ba3507828"
+  integrity sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==
 
 body-parser@1.19.0:
   version "1.19.0"
@@ -3243,9 +3243,9 @@ electron-to-chromium@^1.3.47, electron-to-chromium@^1.3.96:
   integrity sha512-ZUXBUyGLeoJxp4Nt6G/GjBRLnyz8IKQGexZ2ndWaoegThgMGFO1tdDYID5gBV32/1S83osjJHyfzvanE/8HY4Q==
 
 elliptic@^6.0.0:
-  version "6.4.1"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.4.1.tgz#c2d0b7776911b86722c632c3c06c60f2f819939a"
-  integrity sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.3.tgz#cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6"
+  integrity sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==
   dependencies:
     bn.js "^4.4.0"
     brorand "^1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4320,19 +4320,7 @@ glob-to-regexp@^0.3.0:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@~7.1.1:
-  version "7.1.3"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
-  integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.4"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@^7.1.3:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@~7.1.1:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
   integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
@@ -6050,16 +6038,6 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
-lodash.assign@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
-  integrity sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=
-
-lodash.clonedeep@^4.3.2:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
-  integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
-
 lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
@@ -6079,11 +6057,6 @@ lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
-
-lodash.mergewith@^4.6.0:
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz#617121f89ac55f59047c7aec1ccd6654c6590f55"
-  integrity sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==
 
 lodash.sortby@^4.7.0:
   version "4.7.0"
@@ -6529,10 +6502,10 @@ mute-stream@0.0.7:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
   integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
 
-nan@^2.10.0, nan@^2.9.2:
-  version "2.12.1"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.12.1.tgz#7b1aa193e9aa86057e3c7bbd0ac448e770925552"
-  integrity sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==
+nan@^2.13.2, nan@^2.9.2:
+  version "2.14.1"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
+  integrity sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -6699,10 +6672,10 @@ node-releases@^1.1.3:
   dependencies:
     semver "^5.3.0"
 
-node-sass@^4.9.0:
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.11.0.tgz#183faec398e9cbe93ba43362e2768ca988a6369a"
-  integrity sha512-bHUdHTphgQJZaF1LASx0kAviPH7sGlcyNhWade4eVIpFp6tsn7SV8xNMTbsQFpEV9VXpnwTTnNYlfsZXgGgmkA==
+node-sass@^4.13.1:
+  version "4.13.1"
+  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.13.1.tgz#9db5689696bb2eec2c32b98bfea4c7a2e992d0a3"
+  integrity sha512-TTWFx+ZhyDx1Biiez2nB0L3YrCZ/8oHagaDalbuBSlqXgUPsdkUSzJsVxeDO9LtPB49+Fh3WQl3slABo6AotNw==
   dependencies:
     async-foreach "^0.1.3"
     chalk "^1.1.1"
@@ -6711,12 +6684,10 @@ node-sass@^4.9.0:
     get-stdin "^4.0.1"
     glob "^7.0.3"
     in-publish "^2.0.0"
-    lodash.assign "^4.2.0"
-    lodash.clonedeep "^4.3.2"
-    lodash.mergewith "^4.6.0"
+    lodash "^4.17.15"
     meow "^3.7.0"
     mkdirp "^0.5.1"
-    nan "^2.10.0"
+    nan "^2.13.2"
     node-gyp "^3.8.0"
     npmlog "^4.0.0"
     request "^2.88.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6078,10 +6078,10 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.x, lodash@^4.0.0, lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.15, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0, lodash@~4.17.10:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
-  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+lodash@4.x, lodash@^4.0.0, lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0, lodash@~4.17.10:
+  version "4.17.19"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
+  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
 log-symbols@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
# Release 11/21/2020

## Release notes v1.2.0

### Security issues:

* Bump websocket-extensions from 0.1.3 to 0.1.4 #36
* Bump lodash from 4.17.15 to 4.17.19 #37
* Bump elliptic from 6.4.1 to 6.5.3 #38
* Bump node-sass from 4.11.0 to 4.13.1 #39
* Bump http-proxy from 1.17.0 to 1.18.1 #40

### Minor fixes and improvements:

*  Add a button on 404 page to allow users go back to games list: #41 
*  Delete useless argument `type` from clear method in Canvas: #42
