### PR TITLE
Issue #60 Invoke setProperties in Canvas's constructor

### DIFF
--- a/src/game/Canvas.js
+++ b/src/game/Canvas.js
@@ -35,13 +35,9 @@ export class Canvas {
   constructor ({ contexts, grid, map, divHeight }) {
     this._divHeight = divHeight
 
-    this._setupGrid(grid)
-    this._setupMap(map)
     this._setupContexts(contexts)
-    this._resizeContexts()
-    this._locateContexts()
-    this._drawGrid()
-    this._drawBorder()
+
+    this.setPropertions({ grid, map })
   }
 
   _setupGrid ({ dot, line, width, height, border }) {


### PR DESCRIPTION
Bugfix: canvas initialization on Mac OS doesn't draw background in black. Invoke drawing black manualy in Canvas's constructor.

Closes #60